### PR TITLE
Recognize and resolve custom MSBuild variables

### DIFF
--- a/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
@@ -327,13 +327,13 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 
 				string value;
 				bool succeeded = HResultHelpers.SUCCEEDED(vsBuildMacroInfo.GetBuildMacroValue(addedMacro, out value)) && !String.IsNullOrEmpty(value);
-                if (!succeeded)
-                {
-                    value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
-                    succeeded = !String.IsNullOrEmpty(value);
-                }
-
-                lock (_resolvedMacros) {
+				if (!succeeded)
+				{
+					value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
+					succeeded = !String.IsNullOrEmpty(value);
+				}
+				
+				lock (_resolvedMacros) {
 					if (succeeded)
 						_resolvedMacros[addedMacro] = value;
 					else

--- a/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
@@ -206,16 +206,6 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 				_assemblyReferences.Add(assemblyNameOrFile, cookie);
 			return cookie;
 		}
-		
-		/// <summary>
-		/// The <see cref="IVsHierarchy"/> representing the project file normally implements <see cref="IVsBuildMacroInfo"/>.
-		/// </summary>
-		/// <returns>An instance of <see cref="IVsBuildMacroInfo"/> if found.</returns>
-		[CanBeNull]
-		private IVsBuildMacroInfo TryGetVsBuildMacroInfo() {
-			// ReSharper disable once SuspiciousTypeConversion.Global
-			return TryGetVsHierarchy() as IVsBuildMacroInfo;
-		}
 
 		[CanBeNull]
 		private IVsHierarchy TryGetVsHierarchy() {
@@ -314,24 +304,13 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 		/// <returns>Whether at least one macro has been processed.</returns>
 		private bool ResolveMacros([NotNull] IEnumerable<string> macros) {
 			bool hasChanges = false;
-
-			IVsBuildMacroInfo vsBuildMacroInfo = null;
+			
 			foreach (string addedMacro in macros) {
-				if (vsBuildMacroInfo == null) {
-					vsBuildMacroInfo = TryGetVsBuildMacroInfo();
-					if (vsBuildMacroInfo == null)
-						break;
-				}
 
 				hasChanges = true;
 
-				string value;
-				bool succeeded = HResultHelpers.SUCCEEDED(vsBuildMacroInfo.GetBuildMacroValue(addedMacro, out value)) && !String.IsNullOrEmpty(value);
-				if (!succeeded)
-				{
-					value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
-					succeeded = !String.IsNullOrEmpty(value);
-				}
+				string value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
+				bool succeeded = !String.IsNullOrEmpty(value);
 				
 				lock (_resolvedMacros) {
 					if (succeeded)

--- a/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
@@ -206,6 +206,16 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 				_assemblyReferences.Add(assemblyNameOrFile, cookie);
 			return cookie;
 		}
+		
+		/// <summary>
+		/// The <see cref="IVsHierarchy"/> representing the project file normally implements <see cref="IVsBuildMacroInfo"/>.
+		/// </summary>
+		/// <returns>An instance of <see cref="IVsBuildMacroInfo"/> if found.</returns>
+		[CanBeNull]
+		private IVsBuildMacroInfo TryGetVsBuildMacroInfo() {
+			// ReSharper disable once SuspiciousTypeConversion.Global
+			return TryGetVsHierarchy() as IVsBuildMacroInfo;
+		}
 
 		[CanBeNull]
 		private IVsHierarchy TryGetVsHierarchy() {
@@ -304,13 +314,24 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 		/// <returns>Whether at least one macro has been processed.</returns>
 		private bool ResolveMacros([NotNull] IEnumerable<string> macros) {
 			bool hasChanges = false;
-			
+
+			IVsBuildMacroInfo vsBuildMacroInfo = null;
 			foreach (string addedMacro in macros) {
+				if (vsBuildMacroInfo == null) {
+					vsBuildMacroInfo = TryGetVsBuildMacroInfo();
+					if (vsBuildMacroInfo == null)
+						break;
+				}
 
 				hasChanges = true;
 
-				string value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
-				bool succeeded = !String.IsNullOrEmpty(value);
+				string value;
+				bool succeeded = HResultHelpers.SUCCEEDED(vsBuildMacroInfo.GetBuildMacroValue(addedMacro, out value)) && !String.IsNullOrEmpty(value);
+				if (!succeeded)
+				{
+					value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
+					succeeded = !String.IsNullOrEmpty(value);
+				}
 				
 				lock (_resolvedMacros) {
 					if (succeeded)

--- a/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4PsiModule.cs
@@ -327,7 +327,13 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 
 				string value;
 				bool succeeded = HResultHelpers.SUCCEEDED(vsBuildMacroInfo.GetBuildMacroValue(addedMacro, out value)) && !String.IsNullOrEmpty(value);
-				lock (_resolvedMacros) {
+                if (!succeeded)
+                {
+                    value = MSBuildExtensions.GetStringValue(TryGetVsHierarchy(), addedMacro, null);
+                    succeeded = !String.IsNullOrEmpty(value);
+                }
+
+                lock (_resolvedMacros) {
 					if (succeeded)
 						_resolvedMacros[addedMacro] = value;
 					else


### PR DESCRIPTION
(solution for #60)

Properties defined in project files are now resolved in include & assembly paths.

I also removed `TryGetVsBuildMacroInfo` in the third commit, because MSBuildExtensions also returns built-in properties so there's no reason to use two different methods, but feel free to disagree.