### PR TITLE
Add VB.Net Support

### DIFF
--- a/GammaJul.ReSharper.ForTea/Daemon/T4CSharpHighlightingProcess.cs
+++ b/GammaJul.ReSharper.ForTea/Daemon/T4CSharpHighlightingProcess.cs
@@ -136,20 +136,20 @@ namespace GammaJul.ReSharper.ForTea.Daemon {
 
 		[CanBeNull]
 		private static string GetTypeElementHighlightingAttributeId([CanBeNull] ITypeElement element) {
-			return null;
-			// TODO: see why these highlighters fail (no MEF classification)
-			//if (element == null)
-			//	return null;
-			//if (element is IInterface)
-			//	return T4CSharpInterfaceHighlighting.Instance;
-			//if (element is IStruct)
-			//	return T4CSharpStructHighlighting.Instance;
-			//if (element is IEnum)
-			//	return T4CSharpEnumHighlighting.Instance;
-			//if (element is IDelegate)
-			//	return T4CSharpDelegateHighlighting.Instance;
-			//return T4CSharpTypeHighlighting.Instance;
-		}
+			return HighlightingAttributeIds.GetHighlightAttributeForTypeElement(element);
+            // TODO: see why these highlighters fail (no MEF classification)
+            //if (element == null)
+            //	return null;
+            //if (element is IInterface)
+            //	return T4CSharpInterfaceHighlighting.Instance;
+            //if (element is IStruct)
+            //	return T4CSharpStructHighlighting.Instance;
+            //if (element is IEnum)
+            //	return T4CSharpEnumHighlighting.Instance;
+            //if (element is IDelegate)
+            //	return T4CSharpDelegateHighlighting.Instance;
+            //return T4CSharpTypeHighlighting.Instance;
+        }
 
 		public T4CSharpHighlightingProcess(IDaemonProcess process, IContextBoundSettingsStore settingsStore, ICSharpFile file)
 			: base(process, settingsStore, file) {

--- a/GammaJul.ReSharper.ForTea/Daemon/T4CSharpHighlightingProcess.cs
+++ b/GammaJul.ReSharper.ForTea/Daemon/T4CSharpHighlightingProcess.cs
@@ -23,6 +23,7 @@ using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Parsing;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
 using JetBrains.ReSharper.Psi.Parsing;
 using JetBrains.ReSharper.Psi.Tree;
@@ -114,16 +115,25 @@ namespace GammaJul.ReSharper.ForTea.Daemon {
 
 			if (_csharpOperators[tokenType])
 				return VsPredefinedHighlighterIds.Operator;
-			
+
 			if (tokenType.IsIdentifier) {
-				
 				var declaration = element.Parent as ITypeDeclaration;
 				if (declaration != null)
 					return GetTypeElementHighlightingAttributeId(declaration.DeclaredElement);
 
+				ResolveResultWithInfo reference = null;
+
 				var referenceName = element.Parent as IReferenceName;
-				if (referenceName != null) {
-					var typeElement = referenceName.Reference.Resolve().DeclaredElement as ITypeElement;
+				if (referenceName != null)
+					reference = referenceName.Reference.Resolve();
+
+				var referenceExpresion = element.Parent as IReferenceExpression;
+				if (referenceExpresion != null)
+					reference = referenceExpresion.Reference.Resolve();
+
+				if (reference != null)
+				{
+					var typeElement = reference.DeclaredElement as ITypeElement;
 					if (typeElement != null)
 						return GetTypeElementHighlightingAttributeId(typeElement);
 				}
@@ -137,19 +147,19 @@ namespace GammaJul.ReSharper.ForTea.Daemon {
 		[CanBeNull]
 		private static string GetTypeElementHighlightingAttributeId([CanBeNull] ITypeElement element) {
 			return HighlightingAttributeIds.GetHighlightAttributeForTypeElement(element);
-            // TODO: see why these highlighters fail (no MEF classification)
-            //if (element == null)
-            //	return null;
-            //if (element is IInterface)
-            //	return T4CSharpInterfaceHighlighting.Instance;
-            //if (element is IStruct)
-            //	return T4CSharpStructHighlighting.Instance;
-            //if (element is IEnum)
-            //	return T4CSharpEnumHighlighting.Instance;
-            //if (element is IDelegate)
-            //	return T4CSharpDelegateHighlighting.Instance;
-            //return T4CSharpTypeHighlighting.Instance;
-        }
+			// TODO: see why these highlighters fail (no MEF classification)
+			//if (element == null)
+			//	return null;
+			//if (element is IInterface)
+			//	return T4CSharpInterfaceHighlighting.Instance;
+			//if (element is IStruct)
+			//	return T4CSharpStructHighlighting.Instance;
+			//if (element is IEnum)
+			//	return T4CSharpEnumHighlighting.Instance;
+			//if (element is IDelegate)
+			//	return T4CSharpDelegateHighlighting.Instance;
+			//return T4CSharpTypeHighlighting.Instance;
+		}
 
 		public T4CSharpHighlightingProcess(IDaemonProcess process, IContextBoundSettingsStore settingsStore, ICSharpFile file)
 			: base(process, settingsStore, file) {

--- a/GammaJul.ReSharper.ForTea/Daemon/T4VBHighlightingProcess.cs
+++ b/GammaJul.ReSharper.ForTea/Daemon/T4VBHighlightingProcess.cs
@@ -1,0 +1,188 @@
+﻿#region License
+
+//    Copyright 2012 Julien Lebosquain
+//    Copyright 2016 Caelan Sayler - [caelantsayler]at[gmail]com
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#endregion
+
+
+using GammaJul.ReSharper.ForTea.Daemon.Highlightings;
+using JetBrains.Annotations;
+using JetBrains.Application.Settings;
+using JetBrains.ReSharper.Daemon.VB.Stages;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Resolve;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Psi.Parsing;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.VB.Parsing;
+using JetBrains.ReSharper.Psi.VB.Tree;
+
+namespace GammaJul.ReSharper.ForTea.Daemon {
+
+	/// <summary>
+	/// Highlights VB keywords, identifiers, etc.
+	/// Usually, those are colored by Visual Studio language service. However, it's not available in T4 files so we have to do it ourselves.
+	/// </summary>
+	internal class T4VBHighlightingProcess : VBIncrementalDaemonStageProcess {
+
+		private static readonly NodeTypeSet _vbOperators = new NodeTypeSet(
+			VBTokenType.COMMA,
+			VBTokenType.DOT,
+			VBTokenType.EQ,
+			VBTokenType.GT,
+			VBTokenType.GE,
+			VBTokenType.LT,
+			VBTokenType.LE,
+			VBTokenType.NE,
+			VBTokenType.EXCL,
+			VBTokenType.COLON,
+			VBTokenType.PLUS,
+			VBTokenType.PLUSEQ,
+			VBTokenType.MINUS,
+			VBTokenType.MINUSEQ,
+			VBTokenType.ASTERISK,
+			VBTokenType.ASTERISKEQ,
+			VBTokenType.DIV,
+			VBTokenType.DIVEQ,
+			VBTokenType.AND,
+			VBTokenType.ANDEQ,
+			VBTokenType.XOR,
+			VBTokenType.XOREQ,
+			VBTokenType.LTLT,
+			VBTokenType.GTGT,
+			VBTokenType.LTLTEQ,
+			VBTokenType.GTGTEQ,
+			VBTokenType.QUESTION,
+			VBTokenType.TYPECHAR_PERC,
+			VBTokenType.TYPECHAR_AND,
+			VBTokenType.TYPECHAR_EXCL
+			);
+
+		public T4VBHighlightingProcess(IDaemonProcess process, IContextBoundSettingsStore settingsStore, IVBFile file)
+			: base(process, settingsStore, file) {
+		}
+
+		public override void VisitNode(ITreeNode node, IHighlightingConsumer context) {
+			base.VisitNode(node, context);
+
+			var highlightingRange = node.GetHighlightingRange();
+			context.AddHighlighting(new PredefinedHighlighting(VsPredefinedHighlighterIds.RazorCode, highlightingRange));
+			bool xml;
+			var attributeId = GetHighlightingAttributeId(node, out xml);
+
+			if (attributeId != null)
+				context.AddHighlighting(new PredefinedHighlighting(attributeId, highlightingRange));
+
+			// Dim embedded xml literals if desired...
+			//if (xml)
+			//    context.AddHighlighting(new PredefinedHighlighting(HighlightingAttributeIds.DEADCODE_ATTRIBUTE, highlightingRange));
+		}
+
+		[CanBeNull]
+		private static string GetHighlightingAttributeId([NotNull] ITreeNode element, out bool isXml) {
+			isXml = false;
+			var tokenType = element.GetTokenType();
+			if (tokenType == null)
+				return null;
+
+			// XML LITERALS
+			isXml = true;
+			if (tokenType == VBTokenType.XML_SCRIPLET_START || tokenType == VBTokenType.XML_SCRIPLET_END)
+				return VsPredefinedHighlighterIds.HtmlServerSideScript;
+			if (tokenType is XmlTokenNodeType)
+				return GetXmlHighlightingAttributeId(element, tokenType);
+			isXml = false;
+
+			// VB.NET LANGUAGE
+			if (tokenType.IsKeyword)
+				return VsPredefinedHighlighterIds.Keyword;
+			if (tokenType.IsComment)
+				return VsPredefinedHighlighterIds.Comment;
+			if (tokenType.IsStringLiteral)
+				return VsPredefinedHighlighterIds.String;
+
+			if (tokenType.IsConstantLiteral) {
+				if (tokenType == VBTokenType.CHAR_LITERAL)
+					return VsPredefinedHighlighterIds.String;
+
+				return VsPredefinedHighlighterIds.Number;
+			}
+
+			if (_vbOperators[tokenType])
+				return VsPredefinedHighlighterIds.Operator;
+
+			if (tokenType.IsIdentifier) {
+				var vbidentifier = element.Parent as IVBIdentifier;
+				if (vbidentifier != null) {
+					ResolveResultWithInfo reference = null;
+
+					var referenceName = vbidentifier.Parent as IReferenceName;
+					if (referenceName != null)
+						reference = referenceName.Reference.Resolve();
+
+					var referenceExpresion = vbidentifier.Parent as IReferenceExpression;
+					if (referenceExpresion != null)
+						reference = referenceExpresion.Reference.Resolve();
+
+					if (reference != null) {
+						var typeElement = reference.DeclaredElement as ITypeElement;
+						if (typeElement != null)
+							return HighlightingAttributeIds.GetHighlightAttributeForTypeElement(typeElement);
+					}
+				}
+
+				return VsPredefinedHighlighterIds.Identifier;
+			}
+
+			return null;
+		}
+
+		[CanBeNull]
+		private static string GetXmlHighlightingAttributeId(ITreeNode element, TokenNodeType token) {
+			// only highlight the first identifier in an xml tag (the rest are attributes)
+			if (token.IsIdentifier) {
+				var prevSibling = element.PrevSibling;
+				if (prevSibling != null) {
+					var prevSiblingToken = prevSibling.GetTokenType();
+					if (prevSiblingToken != null) {
+						if (prevSiblingToken == VBTokenType.XmlTokens.TAG_START ||
+							prevSiblingToken == VBTokenType.XmlTokens.TAG_START1)
+							return VsPredefinedHighlighterIds.HtmlElementName;
+					}
+				}
+
+				return VsPredefinedHighlighterIds.HtmlAttributeName;
+			}
+
+			if (token == VBTokenType.XmlTokens.TAG_START ||
+				token == VBTokenType.XmlTokens.TAG_END ||
+				token == VBTokenType.XmlTokens.TAG_START1 ||
+				token == VBTokenType.XmlTokens.TAG_END1 ||
+				token == VBTokenType.XmlTokens.EQ)
+				return HighlightingAttributeIds.REGEXP_COMMENT;
+
+			if (token == VBTokenType.XmlTokens.COMMENT_START ||
+				token == VBTokenType.XmlTokens.COMMENT_END ||
+				token == VBTokenType.XmlTokens.COMMENT_BODY)
+				return HighlightingAttributeIds.REGEXP_COMMENT;
+
+			return null;
+		}
+
+	}
+
+}

--- a/GammaJul.ReSharper.ForTea/Daemon/T4VBHighlightingStage.cs
+++ b/GammaJul.ReSharper.ForTea/Daemon/T4VBHighlightingStage.cs
@@ -1,0 +1,49 @@
+﻿#region License
+
+//    Copyright 2012 Julien Lebosquain
+//    Copyright 2016 Caelan Sayler - [caelantsayler]at[gmail]com
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#endregion
+
+
+using GammaJul.ReSharper.ForTea.Psi;
+using JetBrains.Application.Settings;
+using JetBrains.ReSharper.Daemon.Stages;
+using JetBrains.ReSharper.Daemon.UsageChecking;
+using JetBrains.ReSharper.Daemon.VB.Stages;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Feature.Services.VB.Daemon;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.VB.Tree;
+
+namespace GammaJul.ReSharper.ForTea.Daemon {
+
+	[DaemonStage(
+		StagesBefore = new[] { typeof(GlobalFileStructureCollectorStage) },
+		StagesAfter = new[] { typeof(CollectUsagesStage), typeof(VBIdentifierHighlighterStage) })]
+	public class T4VBHighlightingStage : VBDaemonStageBase {
+
+		protected override bool IsSupported(IPsiSourceFile projectFile, IContextBoundSettingsStore settingsStore) {
+			return base.IsSupported(projectFile, settingsStore) && projectFile.IsLanguageSupported<T4Language>();
+		}
+
+		public override IDaemonStageProcess CreateProcess(IDaemonProcess process, IContextBoundSettingsStore settings, DaemonProcessKind processKind,
+			IVBFile file) {
+			return new T4VBHighlightingProcess(process, settings, file);
+		}
+
+	}
+
+}

--- a/GammaJul.ReSharper.ForTea/GammaJul.ReSharper.ForTea.csproj
+++ b/GammaJul.ReSharper.ForTea/GammaJul.ReSharper.ForTea.csproj
@@ -248,6 +248,8 @@
     <Compile Include="Psi\T4ResolveProject.cs" />
     <Compile Include="Psi\T4SecondaryDocumentGenerationResult.cs" />
     <Compile Include="Psi\T4SecondaryLexingProcess.cs" />
+    <Compile Include="Psi\T4VBCodeGenerator.cs" />
+    <Compile Include="Psi\T4VBCustomModificationHandler.cs" />
     <Compile Include="Psi\TextTemplatingComponentsExtensions.cs" />
     <Compile Include="Psi\VsBuildMacroHelper.cs" />
     <Compile Include="Services\CodeCompletion\AutopopupInDirective.cs" />
@@ -277,6 +279,7 @@
     <Compile Include="Services\T4SpecificOwnerUtil.cs" />
     <Compile Include="Services\TypingAssist\T4CSharpTypingAssist.cs" />
     <Compile Include="Services\TypingAssist\T4TypingAssist.cs" />
+    <Compile Include="Services\TypingAssist\T4VBTypingAssist.cs" />
     <Compile Include="SupportedReSharperVersion.cs" />
     <Compile Include="T4Environment.cs" />
     <Compile Include="Tree\IT4Block.cs" />

--- a/GammaJul.ReSharper.ForTea/GammaJul.ReSharper.ForTea.csproj
+++ b/GammaJul.ReSharper.ForTea/GammaJul.ReSharper.ForTea.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Daemon\T4HighlightingProcess.cs" />
     <Compile Include="Daemon\T4HighlightingStage.cs" />
     <Compile Include="Daemon\T4LanguageSpecificDaemonBehavior.cs" />
+    <Compile Include="Daemon\T4VBHighlightingProcess.cs" />
+    <Compile Include="Daemon\T4VBHighlightingStage.cs" />
     <Compile Include="ExposeTextTemplatingEngineHostService.cs" />
     <Compile Include="Intentions\QuickFixes\AddMissingTokenQuickFix.cs" />
     <Compile Include="Intentions\QuickFixes\ChangeAttributeValueQuickFix.cs" />

--- a/GammaJul.ReSharper.ForTea/Psi/Directives/TemplateDirectiveInfo.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/Directives/TemplateDirectiveInfo.cs
@@ -80,7 +80,7 @@ namespace GammaJul.ReSharper.ForTea.Psi.Directives {
 
 			bool isAtLeastVs2012 = environment.VsVersion2.Major >= VsVersions.Vs2012;
 
-			_languageAttribute = new EnumDirectiveAttributeInfo("language", DirectiveAttributeOptions.None, "C#", "VB");
+			_languageAttribute = new EnumDirectiveAttributeInfo("language", DirectiveAttributeOptions.None, "C#", "C#v3.5", "VB", "VBv3.5");
 			_hostSpecificAttribute = isAtLeastVs2012
 				? new EnumDirectiveAttributeInfo("hostspecific",DirectiveAttributeOptions.None, "true", "false", "trueFromBase")
 				: new BooleanDirectiveAttributeInfo("hostspecific", DirectiveAttributeOptions.None);

--- a/GammaJul.ReSharper.ForTea/Psi/T4VBCodeGenerator.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4VBCodeGenerator.cs
@@ -241,7 +241,7 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 			}
 			builder.AppendLine("Imports System");
 			result.Append(_usingsResult);
-			builder.AppendFormat("[{0}]", SyntheticAttribute.Name);
+			builder.AppendFormat("<{0}> _", SyntheticAttribute.Name);
 			builder.AppendLine();
 
 			builder.AppendFormat("Public Class {0} {1} Inherits ", ClassName, Environment.NewLine);

--- a/GammaJul.ReSharper.ForTea/Psi/T4VBCodeGenerator.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4VBCodeGenerator.cs
@@ -1,0 +1,277 @@
+﻿#region License
+
+//    Copyright 2012 Julien Lebosquain
+//    Copyright 2016 Caelan Sayler - [caelantsayler]at[gmail]com
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#endregion
+
+
+using System;
+using GammaJul.ReSharper.ForTea.Psi.Directives;
+using GammaJul.ReSharper.ForTea.Tree;
+using JetBrains.Annotations;
+using JetBrains.Application;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.Tree;
+
+namespace GammaJul.ReSharper.ForTea.Psi {
+
+	/// <summary>
+	/// This class generates a code-behind file from VB embedded statements and directives in the T4 file.
+	/// </summary>
+	internal sealed class T4VBCodeGenerator : IRecursiveElementProcessor {
+
+		internal const string CodeCommentStart = "/*_T4\x200CCodeStart_*/";
+		internal const string CodeCommentEnd = "/*_T4\x200CCodeEnd_*/";
+		internal const string ClassName = "Generated\x200CTransformation";
+		internal const string DefaultBaseClassName = "Microsoft.VisualStudio.TextTemplating.TextTransformation";
+		internal const string TransformTextMethodName = "TransformText";
+		private readonly DirectiveInfoManager _directiveInfoManager;
+		private readonly IT4File _file;
+		private GenerationResult _featureResult;
+		private bool _hasHost;
+		private int _includeDepth;
+		private GenerationResult _inheritsResult;
+		private GenerationResult _parametersResult;
+		private bool _rootFeatureStarted;
+		private GenerationResult _transformTextResult;
+		private GenerationResult _usingsResult;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T4VBCodeGenerator" /> class.
+		/// </summary>
+		/// <param name="file">The associated T4 file whose VB code behind will be generated.</param>
+		/// <param name="directiveInfoManager">An instance of <see cref="DirectiveInfoManager" />.</param>
+		internal T4VBCodeGenerator([NotNull] IT4File file, [NotNull] DirectiveInfoManager directiveInfoManager) {
+			_file = file;
+			_directiveInfoManager = directiveInfoManager;
+		}
+
+		bool IRecursiveElementProcessor.InteriorShouldBeProcessed(ITreeNode element) {
+			return element is IT4CodeBlock
+				|| element is IT4Include;
+		}
+
+		void IRecursiveElementProcessor.ProcessBeforeInterior(ITreeNode element) {
+			if (element is IT4Include)
+				++_includeDepth;
+		}
+
+		void IRecursiveElementProcessor.ProcessAfterInterior(ITreeNode element) {
+			if (element is IT4Include) {
+				--_includeDepth;
+				return;
+			}
+
+			var directive = element as IT4Directive;
+			if (directive != null) {
+				HandleDirective(directive);
+				return;
+			}
+
+			var codeBlock = element as IT4CodeBlock;
+			if (codeBlock != null)
+				HandleCodeBlock(codeBlock);
+		}
+
+		bool IRecursiveElementProcessor.ProcessingIsFinished
+		{
+			get
+			{
+				InterruptableActivityCookie.CheckAndThrow();
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Handles a directive in the tree.
+		/// </summary>
+		/// <param name="directive">The directive.</param>
+		private void HandleDirective([NotNull] IT4Directive directive) {
+			if (directive.IsSpecificDirective(_directiveInfoManager.Import))
+				HandleImportDirective(directive);
+			else if (directive.IsSpecificDirective(_directiveInfoManager.Template))
+				HandleTemplateDirective(directive);
+			else if (directive.IsSpecificDirective(_directiveInfoManager.Parameter))
+				HandleParameterDirective(directive);
+		}
+
+		/// <summary>
+		/// Handles an import directive, equivalent of an using directive in VB.Net.
+		/// </summary>
+		/// <param name="directive">The import directive.</param>
+		private void HandleImportDirective([NotNull] IT4Directive directive) {
+			var ns = directive.GetAttributeValueIgnoreOnlyWhitespace(_directiveInfoManager.Import.NamespaceAttribute.Name);
+			if (ns.First == null || ns.Second == null)
+				return;
+
+			_usingsResult.Builder.Append("Imports ");
+			_usingsResult.AppendMapped(ns.Second, ns.First.GetTreeTextRange());
+			_usingsResult.Builder.AppendLine();
+		}
+
+		/// <summary>
+		/// Handles a template directive, determining if we should output a Host property and use a base class.
+		/// </summary>
+		/// <param name="directive">The template directive.</param>
+		private void HandleTemplateDirective([NotNull] IT4Directive directive) {
+			var value = directive.GetAttributeValue(_directiveInfoManager.Template.HostSpecificAttribute.Name);
+			_hasHost = bool.TrueString.Equals(value, StringComparison.OrdinalIgnoreCase);
+
+			var className = directive.GetAttributeValueIgnoreOnlyWhitespace(_directiveInfoManager.Template.InheritsAttribute.Name);
+			if (className.First != null && className.Second != null)
+				_inheritsResult.AppendMapped(className.Second, className.First.GetTreeTextRange());
+		}
+
+		/// <summary>
+		/// Handles a parameter directive, outputting an extra property.
+		/// </summary>
+		/// <param name="directive">The parameter directive.</param>
+		private void HandleParameterDirective([NotNull] IT4Directive directive) {
+			var type = directive.GetAttributeValueIgnoreOnlyWhitespace(_directiveInfoManager.Parameter.TypeAttribute.Name);
+			if (type.First == null || type.Second == null)
+				return;
+
+			var name = directive.GetAttributeValueIgnoreOnlyWhitespace(_directiveInfoManager.Parameter.NameAttribute.Name);
+			if (name.First == null || name.Second == null)
+				return;
+
+			var builder = _parametersResult.Builder;
+			builder.AppendLine("<System.CodeDom.Compiler.GeneratedCodeAttribute> _");
+			builder.Append("Private ReadOnly Property Global.");
+			_parametersResult.AppendMapped(name.Second, name.First.GetTreeTextRange()); // name
+			builder.Append(" As ");
+			_parametersResult.AppendMapped(type.Second, type.First.GetTreeTextRange()); // type
+			builder.AppendLine();
+			builder.AppendLine("Get");
+			builder.Append("Return Nothing"); // closest thing to default() keyword...
+			builder.AppendLine("End Get");
+			builder.AppendLine("End Property");
+		}
+
+		/// <summary>
+		/// Handles a code block: depending of whether it's a feature or transform text result,
+		/// it is not added to the same part of the VB.Net file.
+		/// </summary>
+		/// <param name="codeBlock">The code block.</param>
+		private void HandleCodeBlock([NotNull] IT4CodeBlock codeBlock) {
+			var codeToken = codeBlock.GetCodeToken();
+			if (codeToken == null)
+				return;
+
+			GenerationResult result;
+			var expressionBlock = codeBlock as T4ExpressionBlock;
+
+			if (expressionBlock != null) {
+				result = _rootFeatureStarted && _includeDepth == 0 ? _featureResult : _transformTextResult;
+				result.Builder.Append("Me.Write(__\x200CToString(");
+			}
+			else {
+				if (codeBlock is T4FeatureBlock) {
+					if (_includeDepth == 0)
+						_rootFeatureStarted = true;
+					result = _featureResult;
+				}
+				else
+					result = _transformTextResult;
+			}
+
+			result.Builder.Append(CodeCommentStart);
+			result.AppendMapped(codeToken);
+			result.Builder.Append(CodeCommentEnd);
+
+			if (expressionBlock != null)
+				result.Builder.Append("))");
+			result.Builder.AppendLine();
+		}
+
+		/// <summary>
+		/// Gets the namespace of the current T4 file. This is always <c>null</c> for a standard (non-preprocessed) file.
+		/// </summary>
+		/// <returns>A namespace, or <c>null</c>.</returns>
+		[CanBeNull]
+		private string GetNamespace() {
+			var sourceFile = _file.GetSourceFile();
+			if (sourceFile == null)
+				return null;
+			var projectFile = sourceFile.ToProjectFile();
+			if (projectFile == null || !projectFile.IsPreprocessedT4Template())
+				return null;
+
+			var ns = projectFile.GetCustomToolNamespace();
+			if (!string.IsNullOrEmpty(ns))
+				return ns;
+
+			return sourceFile.Properties.GetDefaultNamespace();
+		}
+
+		/// <summary>
+		/// Generates a new VB code behind.
+		/// </summary>
+		/// <returns>An instance of <see cref="GenerationResult" /> containing the VB file.</returns>
+		[NotNull]
+		internal GenerationResult Generate() {
+			_usingsResult = new GenerationResult(_file);
+			_parametersResult = new GenerationResult(_file);
+			_inheritsResult = new GenerationResult(_file);
+			_transformTextResult = new GenerationResult(_file);
+			_featureResult = new GenerationResult(_file);
+			_file.ProcessDescendants(this);
+
+			var result = new GenerationResult(_file);
+			var builder = result.Builder;
+
+			var ns = GetNamespace();
+			var hasNamespace = !string.IsNullOrEmpty(ns);
+			if (hasNamespace) {
+				builder.AppendFormat("Namespace {0} ", ns);
+				builder.AppendLine();
+			}
+			builder.AppendLine("Imports System");
+			result.Append(_usingsResult);
+			builder.AppendFormat("[{0}]", SyntheticAttribute.Name);
+			builder.AppendLine();
+
+			builder.AppendFormat("Public Class {0} {1} Inherits ", ClassName, Environment.NewLine);
+			if (_inheritsResult.Builder.Length == 0)
+				builder.Append(DefaultBaseClassName);
+			else
+				result.Append(_inheritsResult);
+			builder.AppendLine();
+			builder.AppendFormat("<{0}> _", SyntheticAttribute.Name);
+			builder.AppendLine();
+			builder.AppendLine("Private Shared Function __\x200CToString(value As Object) As String");
+			builder.AppendLine("Return Nothing");
+			builder.AppendLine("End Function");
+			if (_hasHost)
+				builder.AppendLine("Public Overridable Property Host As Microsoft.VisualStudio.TextTemplating.ITextTemplatingEngineHost");
+			result.Append(_parametersResult);
+			builder.AppendLine("<System.CodeDom.Compiler.GeneratedCodeAttribute> _");
+			builder.AppendFormat("Public Overrides Function {0}() As String", TransformTextMethodName);
+			builder.AppendLine();
+			result.Append(_transformTextResult);
+			builder.AppendLine();
+			builder.AppendLine("Return GenerationEnvironment.ToString()");
+			builder.AppendLine("End Function");
+			result.Append(_featureResult);
+			builder.AppendLine("End Class");
+			if (hasNamespace)
+				builder.AppendLine("End Namespace");
+			return result;
+		}
+
+	}
+
+}

--- a/GammaJul.ReSharper.ForTea/Psi/T4VBCustomModificationHandler.cs
+++ b/GammaJul.ReSharper.ForTea/Psi/T4VBCustomModificationHandler.cs
@@ -1,0 +1,197 @@
+﻿#region License
+
+//    Copyright 2012 Julien Lebosquain
+//    Copyright 2016 Caelan Sayler - [caelantsayler]at[gmail]com
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#endregion
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GammaJul.ReSharper.ForTea.Parsing;
+using GammaJul.ReSharper.ForTea.Psi.Directives;
+using GammaJul.ReSharper.ForTea.Tree;
+using JetBrains.Annotations;
+using JetBrains.DocumentModel;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Psi.Impl.Shared;
+using JetBrains.ReSharper.Psi.Modules;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.VB;
+using JetBrains.ReSharper.Psi.VB.Impl.CustomHandlers;
+using JetBrains.ReSharper.Psi.VB.Parsing;
+using JetBrains.ReSharper.Psi.VB.Tree;
+using JetBrains.ReSharper.Psi.Web.CodeBehindSupport;
+using JetBrains.Util;
+
+namespace GammaJul.ReSharper.ForTea.Psi {
+
+	/// <summary>
+	/// VB custom modification handler that allows the T4 files to be modified in response to VB actions or quickfixes.
+	/// (eg: adding a VB Import statement translates to a T4 import directive).
+	/// </summary>
+	[ProjectFileType(typeof(T4ProjectFileType))]
+	public class T4VBCustomModificationHandler : CustomModificationHandler<IT4CodeBlock, IT4Directive>, IVBCustomModificationHandler {
+
+		[NotNull] private readonly DirectiveInfoManager _directiveInfoManager;
+
+		public T4VBCustomModificationHandler([NotNull] ILanguageManager languageManager, [NotNull] DirectiveInfoManager directiveInfoManager)
+			: base(languageManager) {
+			_directiveInfoManager = directiveInfoManager;
+		}
+
+		public bool CanRemoveUsing(IDocument document, IImportDirective usingDirective) {
+			var nameRange = GetNameRange(usingDirective);
+			if (!nameRange.IsValid())
+				return false;
+
+			var containingFile = usingDirective.GetContainingFile();
+			if (containingFile == null)
+				return false;
+
+			var documentRange = containingFile.GetDocumentRange(nameRange);
+			return documentRange.IsValid() && documentRange.Document == document;
+		}
+
+		public void HandleRemoveStatementsRange(IPsiServices psiServices, ITreeRange treeRange, Action action) {
+			action();
+		}
+
+		public IVBStatementsRange HandleAddStatementsRange(IPsiServices psiServices, Func<IVBStatementsRange> addAction, bool before) {
+			var transaction = psiServices.Transactions;
+			using (CustomGeneratedChangePromotionCookie.Create<VBLanguage>(transaction)) {
+				var range = addAction();
+				FinishAddStatementsRange(range.TreeRange, before);
+				return range;
+			}
+		}
+
+		public void HandleRemoveImport(IPsiServices psiServices, IVBTypeAndNamespaceHolderDeclaration scope, IImportDirective usingDirective,
+			Action action) {
+			var range = usingDirective.GetTreeTextRange();
+			HandleRemoveImportInternal(psiServices, scope, usingDirective, action, VBLanguage.Instance, range);
+		}
+
+		public IImportDirective HandleAddImport(IPsiServices psiServices, Func<IImportDirective> action, ITreeNode generatedAnchor, bool before,
+			IFile generatedFile) {
+			return (IImportDirective) HandleAddImportInternal(psiServices, action, generatedAnchor, before, VBLanguage.Instance, generatedFile);
+		}
+
+		public bool CanUseAliases
+		{
+			get { return false; }
+		}
+
+		protected override IT4CodeBlock CreateInlineCodeBlock(string text, ITreeNode anchor) {
+			var existingFeatureNode = anchor.FindPrevNode(node => node is T4FeatureBlock ? TreeNodeActionType.ACCEPT : TreeNodeActionType.CONTINUE);
+			return existingFeatureNode != null
+				? (IT4CodeBlock) T4ElementFactory.Instance.CreateFeatureBlock(text)
+				: T4ElementFactory.Instance.CreateStatementBlock(text);
+		}
+
+		protected override TreeTextRange GetCodeTreeTextRange(IT4CodeBlock codeBlock) {
+			var codeToken = codeBlock.GetCodeToken();
+			return codeToken != null ? codeToken.GetTreeTextRange() : TreeTextRange.InvalidRange;
+		}
+
+		protected override TreeTextRange GetNameRange(ITreeNode usingDirective) {
+			return (usingDirective as IImportDirective).GetTreeTextRange();
+		}
+
+		protected override void RemoveUsingNode(IFile originalFile, IT4Directive directiveInOriginalFile) {
+			((IT4File) originalFile).RemoveDirective(directiveInOriginalFile);
+		}
+
+		protected override TreeTextRange CreateTypeMemberNode(IFile originalFile, string text, ITreeNode first, ITreeNode last) {
+			var featureBlock = T4ElementFactory.Instance.CreateFeatureBlock(text);
+			featureBlock = ((IT4File) originalFile).AddFeatureBlock(featureBlock);
+			return featureBlock.GetCodeToken().GetTreeTextRange();
+		}
+
+		protected override ITreeNode CreateNewLineToken(IPsiModule psiModule) {
+			return VBTokenType.LINE_TERMINATOR.CreateLeafElement();
+		}
+
+		protected override TreeTextRange GetExistingTypeMembersRange(IFile originalFile) {
+			var lastFeatureBlock = ((IT4File) originalFile).GetFeatureBlocks().LastOrDefault();
+			return lastFeatureBlock == null
+				? TreeTextRange.InvalidRange
+				: lastFeatureBlock.GetCodeToken().GetTreeTextRange();
+		}
+
+		protected override void AddSuperClassDirectiveToOriginalFile(IFile originalFile, ITreeNode anchor, ITreeNode superClassGeneratedNode) {
+			var t4File = (IT4File) originalFile;
+			var directive = t4File.GetDirectives(_directiveInfoManager.Template).FirstOrDefault();
+			IT4DirectiveAttribute attribute;
+			var superClassName = superClassGeneratedNode.GetText();
+
+			if (directive == null) {
+				directive =
+					_directiveInfoManager.Template.CreateDirective(Pair.Of(_directiveInfoManager.Template.InheritsAttribute.Name, superClassName));
+				directive = t4File.AddDirective(directive, _directiveInfoManager);
+				attribute = directive.GetAttributes().First();
+			}
+			else
+				attribute = directive.AddAttribute(_directiveInfoManager.Template.InheritsAttribute.CreateDirectiveAttribute(superClassName));
+
+			superClassGeneratedNode.GetRangeTranslator().AddProjectionItem(
+				new TreeTextRange<Generated>(superClassGeneratedNode.GetTreeTextRange()),
+				new TreeTextRange<Original>(attribute.GetValueToken().GetTreeTextRange()));
+		}
+
+		protected override ITreeNode GetSuperClassNodeFromOriginalFile(IFile originalFile) {
+			var t4File = (IT4File) originalFile;
+			foreach (var templateDirective in t4File.GetDirectives(_directiveInfoManager.Template)) {
+				var inheritsToken = templateDirective.GetAttributeValueToken(_directiveInfoManager.Template.InheritsAttribute.Name);
+				if (inheritsToken != null)
+					return inheritsToken;
+			}
+			return null;
+		}
+
+		protected override TreeTextRange CreateUsingNode(bool before, IT4Directive anchor, ITreeNode usingNode, IFile originalFile) {
+			var t4File = (IT4File) originalFile;
+			var ranges = new List<TreeTextRange>();
+
+			var importDirective = (IImportDirective) usingNode;
+			foreach (var claus in importDirective.ImportClauses) {
+				var namespaceClaus = claus as IImportNamespaceClause;
+				if (namespaceClaus == null)
+					continue;
+				var namespaceNode = namespaceClaus.ImportedNamespaceReferenceName;
+				if (namespaceNode == null)
+					continue;
+
+				var ns = namespaceNode.QualifiedName;
+				var directive = _directiveInfoManager.Import.CreateDirective(ns);
+				if (anchor != null && anchor.GetContainingNode<IT4Include>() == null)
+					directive = before ? t4File.AddDirectiveBefore(directive, anchor) : t4File.AddDirectiveAfter(directive, anchor);
+				else
+					directive = t4File.AddDirective(directive, _directiveInfoManager);
+
+				ranges.Add(directive.GetAttributeValueToken(_directiveInfoManager.Import.NamespaceAttribute.Name).GetTreeTextRange());
+			}
+
+			var minRange = ranges.Min(m => m.GetMinOffset().Offset);
+			var maxRange = ranges.Max(m => m.GetMaxOffset().Offset);
+			return new TreeTextRange(new TreeOffset(minRange), new TreeOffset(maxRange));
+		}
+
+	}
+
+}

--- a/GammaJul.ReSharper.ForTea/Services/TypingAssist/T4VBTypingAssist.cs
+++ b/GammaJul.ReSharper.ForTea/Services/TypingAssist/T4VBTypingAssist.cs
@@ -1,0 +1,86 @@
+﻿#region License
+
+//    Copyright 2012 Julien Lebosquain
+//    Copyright 2016 Caelan Sayler - [caelantsayler]at[gmail]com
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#endregion
+
+
+using GammaJul.ReSharper.ForTea.Psi;
+using JetBrains.Application.CommandProcessing;
+using JetBrains.Application.Settings;
+using JetBrains.DataFlow;
+using JetBrains.DocumentManagers;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.CodeCompletion;
+using JetBrains.ReSharper.Feature.Services.TypingAssist;
+using JetBrains.ReSharper.Feature.Services.VB.TypingAssist;
+using JetBrains.ReSharper.Feature.Services.Web.TypingAssist;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CachingLexers;
+using JetBrains.ReSharper.Psi.VB;
+using JetBrains.TextControl;
+
+namespace GammaJul.ReSharper.ForTea.Services.TypingAssist {
+
+	/// <summary>
+	/// Typing assistant for VB embedded in T4 files.
+	/// </summary>
+	[SolutionComponent]
+	public class T4VBTypingAssist : VBTypingAssistBase {
+
+		/// <summary>
+		/// Gets whether a given text control is supported by the assistant.
+		/// </summary>
+		/// <param name="textControl">The text control to check.</param>
+		/// <returns><c>true</c> if <paramref name="textControl" /> is a T4 file with VB code behind, <c>false</c> otherwise.</returns>
+		protected override bool IsSupported(ITextControl textControl) {
+			return WebTypingAssistUtil.IsProjectFileSupported<T4ProjectFileType, VBLanguage>(textControl, Solution);
+		}
+
+		/// <summary>
+		/// Returns the offset difference between a text control and a lexer.
+		/// </summary>
+		/// <param name="textControl">The text control.</param>
+		/// <param name="offset">The original offset.</param>
+		/// <returns>Always <paramref name="offset" />.</returns>
+		public override int TextControlToLexer(ITextControl textControl, int offset) {
+			return offset;
+		}
+
+		/// <summary>
+		/// Returns the offset difference between a lexer and a text control.
+		/// </summary>
+		/// <param name="textControl">The text control.</param>
+		/// <param name="offset">The original offset.</param>
+		/// <returns>Always <paramref name="offset" />.</returns>
+		public override int LexerToTextControl(ITextControl textControl, int offset) {
+			return offset;
+		}
+
+		public override bool QuickCheckAvailability(ITextControl textControl, IPsiSourceFile projectFile) {
+			return projectFile.LanguageType.Is<T4ProjectFileType>();
+		}
+
+		protected T4VBTypingAssist(Lifetime lifetime, ISolution solution, DocumentManager documentManager, ISettingsStore settingsStore,
+			CachingLexerService cachingLexerService, ICommandProcessor commandProcessor, ITypingAssistManager typingAssistManager,
+			IPsiServices psiServices, IExternalIntellisenseHost externalIntellisenseHost)
+			: base(lifetime, solution, documentManager, settingsStore, cachingLexerService, commandProcessor, typingAssistManager,
+				psiServices, externalIntellisenseHost) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
I don't have the latest ReSharper, so I developed this code against an older commit targetting 9.1 and merged into the latest when I was finished. Because of this, I wasn't able to do any final testing before this pull - but can confirm it was working before the merge. I used Issue #33 as a guideline.

Here are the items listed in the issue and completion status:
- [x] Create `T4CSharpCodeGenerator`
- [x] Implement `IVBCustomModificationHandler`
- [x] Implement `VBTypingAssistBase`
- [x] Add VB Daemon Stage for highlighting
- [ ] Add VB Daemon Stage for errors
- [ ] Add IProjectFileCodeStructureProvider

I changed the C# Daemon highlighting stage to use default (C++) ReSharper type highlighting, so that types and namespaces can be differentiated. I also added `C#v3.5` and `VBv3.5` to the valid attribute values for the template language, as unless these are used `TextTransform.exe` defaults to using .Net 2.0

I don't plan on implementing the final two items, because this is good enough for me. 
