### PR TITLE
Update for Resharper 2019 2

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -116,7 +116,9 @@ internal class Build : NukeBuild {
 
 	private string GetWaveVersion()
 		=> NuGetPackageResolver.GetLocalInstalledPackages(MainProjectDirectory / (MainProjectName + ".csproj"))
-			.SingleOrDefault(x => x.Id == "Wave")
+			.Where(x => x.Id == "Wave")
+			.OrderByDescending(x => x.Version.Version)
+			.FirstOrDefault()
 			.NotNull("fullWaveVersion != null")
 			.Version
 			.Version

--- a/source/GammaJul.ReSharper.ForTea/Daemon/Highlightings/MissingTransformTextMethodHighlighting.cs
+++ b/source/GammaJul.ReSharper.ForTea/Daemon/Highlightings/MissingTransformTextMethodHighlighting.cs
@@ -16,7 +16,7 @@ namespace GammaJul.ReSharper.ForTea.Daemon.Highlightings {
 	public class MissingTransformTextMethodHighlighting : IHighlighting {
 
 		[NotNull]
-		public IDeclaredTypeUsage DeclaredTypeUsage { get; }
+		public IUserTypeUsage DeclaredTypeUsage { get; }
 
 		public bool IsValid()
 			=> DeclaredTypeUsage.IsValid();
@@ -30,7 +30,7 @@ namespace GammaJul.ReSharper.ForTea.Daemon.Highlightings {
 		public DocumentRange CalculateRange()
 			=> DeclaredTypeUsage.GetNavigationRange();
 
-		public MissingTransformTextMethodHighlighting([NotNull] IDeclaredTypeUsage declaredTypeUsage) {
+		public MissingTransformTextMethodHighlighting([NotNull] IUserTypeUsage declaredTypeUsage) {
 			DeclaredTypeUsage = declaredTypeUsage;
 		}
 

--- a/source/GammaJul.ReSharper.ForTea/Daemon/T4CSharpErrorProcess.cs
+++ b/source/GammaJul.ReSharper.ForTea/Daemon/T4CSharpErrorProcess.cs
@@ -23,12 +23,13 @@ namespace GammaJul.ReSharper.ForTea.Daemon {
 			|| !T4CSharpCodeGenerator.ClassName.Equals(classDeclarationParam.DeclaredName, StringComparison.Ordinal))
 				return;
 
-			IDeclaredTypeUsage superTypeUsage = classDeclarationParam.SuperTypeUsageNodes.FirstOrDefault();
+			IUserTypeUsage superTypeUsage = classDeclarationParam.SuperTypeUsageNodes.OfType<IUserTypeUsage>().FirstOrDefault();
 			if (superTypeUsage == null
 			|| T4CSharpCodeGenerator.DefaultBaseClassName.Equals(superTypeUsage.GetText(), StringComparison.Ordinal))
 				return;
 
-			ITypeElement typeElement = CSharpTypeFactory.CreateDeclaredType(superTypeUsage).GetTypeElement();
+			NullableAnnotation nullableAnnotation = NullableTypeUsageNavigator.GetByUnderlyingType(superTypeUsage) != null ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated;
+			ITypeElement typeElement = CSharpTypeFactory.CreateDeclaredType(superTypeUsage.ScalarTypeName, nullableAnnotation).GetTypeElement();
 			if (typeElement == null)
 				return;
 			

--- a/source/GammaJul.ReSharper.ForTea/GammaJul.ReSharper.ForTea.csproj
+++ b/source/GammaJul.ReSharper.ForTea/GammaJul.ReSharper.ForTea.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.1.0">
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/source/GammaJul.ReSharper.ForTea/Intentions/QuickFixes/CreateTransformTextMethodQuickFix.cs
+++ b/source/GammaJul.ReSharper.ForTea/Intentions/QuickFixes/CreateTransformTextMethodQuickFix.cs
@@ -34,12 +34,13 @@ namespace GammaJul.ReSharper.ForTea.Intentions.QuickFixes {
 			=> String.Format(CultureInfo.InvariantCulture, "Create method '{0}'", T4CSharpCodeGenerator.TransformTextMethodName);
 
 		[CanBeNull]
-		private static ITypeDeclaration GetTargetTypeDeclaration([NotNull] IDeclaredTypeUsage declaredTypeUsage) {
+		private static ITypeDeclaration GetTargetTypeDeclaration([NotNull] IUserTypeUsage declaredTypeUsage) {
 			if (!declaredTypeUsage.IsValid())
 				return null;
 
+			NullableAnnotation nullableAnnotation = NullableTypeUsageNavigator.GetByUnderlyingType(declaredTypeUsage) != null ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated;
 			return CSharpTypeFactory
-				.CreateDeclaredType(declaredTypeUsage)
+				.CreateDeclaredType(declaredTypeUsage.ScalarTypeName, nullableAnnotation)
 				.GetTypeElement()
 				?.GetDeclarations()
 				.OfType<ITypeDeclaration>()

--- a/source/GammaJul.ReSharper.ForTea/Psi/T4Language.cs
+++ b/source/GammaJul.ReSharper.ForTea/Psi/T4Language.cs
@@ -12,7 +12,7 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 
 		/// <summary>Gets an unique instance of <see cref="T4Language"/>.</summary>
 		[UsedImplicitly(ImplicitUseKindFlags.Assign)]
-		public static T4Language Instance;
+		public static T4Language Instance { get; private set; }
 
 		private T4Language()
 			: base(Name, Name) {

--- a/source/GammaJul.ReSharper.ForTea/Psi/T4OutsideSolutionSourceFileManager.cs
+++ b/source/GammaJul.ReSharper.ForTea/Psi/T4OutsideSolutionSourceFileManager.cs
@@ -66,7 +66,7 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 			_psiProjectFileTypeCoordinator = psiProjectFileTypeCoordinator;
 			_documentManager = documentManager;
 			_sourceFiles = new StrongToWeakDictionary<FileSystemPath, IPsiSourceFile>(lifetime);
-			_psiModule = new PsiModuleOnFileSystemPaths(solution, "T4OutsideSolution", Guid.NewGuid().ToString(), t4Environment.TargetFrameworkId, fileSystemTracker, lifetime);
+			_psiModule = new PsiModuleOnFileSystemPaths(solution, "T4OutsideSolution", Guid.NewGuid().ToString(), t4Environment.TargetFrameworkId, fileSystemTracker, lifetime, true);
 			lifetime.OnTermination(_sourceFiles);
 		}
 

--- a/source/GammaJul.ReSharper.ForTea/Psi/T4ProjectFileType.cs
+++ b/source/GammaJul.ReSharper.ForTea/Psi/T4ProjectFileType.cs
@@ -10,7 +10,7 @@ namespace GammaJul.ReSharper.ForTea.Psi {
 
 		/// <summary>Gets an unique instance of <see cref="T4ProjectFileType"/>.</summary>
 		[UsedImplicitly(ImplicitUseKindFlags.Assign)]
-		public new static readonly T4ProjectFileType Instance;
+		public new static T4ProjectFileType Instance { get; private set; }
 
 		/// <summary>Gets the name of the file type.</summary>
 		public new const string Name = T4Language.Name;


### PR DESCRIPTION
This addresses issue #104 by adding support for R# 2019.2.2.

Summary of changes:

- Replaced old `IDeclaredTypeUsage` with `IUserTypeUsage`
- Changed `Instance` pattern to be a property rather than a field. The latest R# SDK docs at this time seem to be outdated - R# now looks for declared, static, public _properties_ that return the same type as the containing class.
- Modified `GetWaveVersion()` to return the latest version, if more than one available. I'm not sure if this was a result of my environment or not, but the previous implementation would fail at build time because multiple "Wave" packages were found.

I've tested this thoroughly on VS2017 with R# 2019.2.2 using preprocessed T4 templates.